### PR TITLE
Fix CSS li selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
       color: var(--color-primary);
     }
 
-    li+li {
+    main li+li {
       margin-block-start: .4rem;
     }
 


### PR DESCRIPTION
The `li` elements in `header` and `footer` are not vertically aligned at the moment. This PR fixes my bad CSS with a not a future-proof update to the selector:

![li-in-header-footer](https://user-images.githubusercontent.com/8544092/170339231-b8e21b05-0dbf-47f6-9231-d4b90dbe7dfe.png)
